### PR TITLE
ci: add sync-upstream ci

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,31 @@
+name: sync-upstream
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  sync-upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run sync-branches
+        uses: autowarefoundation/autoware-github-actions/sync-branches@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          base-branch: main
+          sync-pr-branch: sync-upstream
+          sync-target-repository: https://github.com/AutomotiveAIChallenge/aichallenge-2024.git
+          sync-target-branch: main
+          pr-title: "chore: sync upstream"
+          pr-labels: |
+            ci
+            sync-upstream
+          auto-merge-method: merge


### PR DESCRIPTION
　[フォーク元](https://github.com/AutomotiveAIChallenge/aichallenge-2024)のmainブランチから、本リポジトリのmainブランチへのsync PRを定期的に作成するCIを追加