### PR TITLE
ci: add spell-check ci

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,47 @@
+{
+  "ignorePaths": [
+    "**/*.cspell.json",
+    "**/*.dae",
+    "**/*.html",
+    "**/*.mp3",
+    "**/*.mp4",
+    "**/*.pcd",
+    "**/*.stl",
+    "**/*.svg",
+    "**/*.wav",
+    "**/*.zip",
+    "**/.git/**",
+    "**/.gitignore",
+    "**/.vscode/**",
+    "**/build/**",
+    "**/CHANGELOG.rst",
+    "**/CPPLINT.cfg",
+    "**/Doxyfile",
+    "**/install/**",
+    "**/log/**",
+    "**/package-lock.json"
+  ],
+  "ignoreRegExpList": [
+    "\\[.*/.*\\]\\(https://github.com",
+    "Copyright .*[0-9]{4}.+",
+    "github.com[/:][\\w._\\-]+(/[\\w._\\-]+)?",
+    "ppa:.+/[^\\s]+",
+    "@[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}"
+  ],
+  "overrides": [
+    {
+      "filename": "**/*.yaml",
+      "ignoreRegExpList": ["author: .+$", "git_email: .+$", "git_user: .+$", "uses: .+$"]
+    },
+    {
+      "filename": "**/package.xml",
+      "ignoreRegExpList": ["<author.*?</author>", "<maintainer.*?</maintainer>"]
+    },
+    {
+      "filename": "**/{*.cpp,*.hpp}",
+      "ignoreRegExpList": ["@author .*$", "[\\@]tparam", "\\author .*$", "Author(s)?( )?: .*$"]
+    }
+  ],
+  "words": [
+  ]
+}

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -1,0 +1,18 @@
+name: spell-check-differential
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  spell-check-differential:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run spell check
+        uses: streetsidesoftware/cspell-action@v6
+        with:
+          config: .cspell.json
+          incremental_files_only: true

--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -1,0 +1,20 @@
+name: spell-check
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run spell check
+        uses: streetsidesoftware/cspell-action@v6
+        with:
+          config: .cspell.json
+          incremental_files_only: false


### PR DESCRIPTION
スペルチェックを行うCIを２種追加（フルチェックと差分チェック）。

フルチェックはmainの更新と手動実行がトリガー
差分チェックはmainへのPRがトリガー