### PR TITLE
ci: change PR label for CI

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -26,6 +26,6 @@ jobs:
           sync-target-branch: main
           pr-title: "chore: sync upstream"
           pr-labels: |
-            ci
+            bot
             sync-upstream
           auto-merge-method: merge


### PR DESCRIPTION
CIが利用するラベルを `ci` から `bot` に変更