### PR TITLE
chore: run pkill when run evaluation

### DIFF
--- a/aichallenge/pkill_all.sh
+++ b/aichallenge/pkill_all.sh
@@ -1,4 +1,6 @@
+pkill -9 AWSIM.x86_64
 pkill -9 component_conta
+pkill -9 dummy_objects_p
 pkill -9 ekf_localizer
 pkill -9 empty_objects_p
 pkill -9 goal_pose_sette

--- a/aichallenge/run_evaluation.bash
+++ b/aichallenge/run_evaluation.bash
@@ -1,6 +1,9 @@
 #!/bin/bash
 AWSIM_DIRECTORY=/aichallenge/simulator/AWSIM
 
+# Kill all processes
+source /aichallenge/pkill_all.sh
+
 # Move working directory
 OUTPUT_DIRECTORY=$(date +%Y%m%d-%H%M%S)
 cd /output || exit


### PR DESCRIPTION
- プロセスキルの対象に `dummy_objects_p` と `AWSIM.x86_64` を追加
- evaluation実行時にプロセスキルを行うように変更