### PR TITLE
ci: add "gird" to flagWords in .cspell.json

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -46,6 +46,9 @@
       "ignoreRegExpList": ["@author .*$", "[\\@]tparam", "\\author .*$", "Author(s)?( )?: .*$", "TODO\\((.*?)\\)"]
     }
   ],
+  "flagWords": [
+    "gird"
+  ],
   "words": [
     "ackermann",
     "adapi",


### PR DESCRIPTION
　#35 のスペルミスの再発防止として、"gird"のtypoである"gird"をflagWords(=ブラックリスト)に追加します。