### PR TITLE
Chore (control): Make steering gain tunable from rqt in simple_pure_pursuit

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/include/simple_pure_pursuit/simple_pure_pursuit.hpp
+++ b/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/include/simple_pure_pursuit/simple_pure_pursuit.hpp
@@ -56,7 +56,7 @@ class SimplePurePursuit : public rclcpp::Node {
   double external_target_vel_;
   double curve_param_max_steer_angle_;
   double curve_param_deceleration_vel_;
-  const double steering_tire_angle_gain_;
+  double steering_tire_angle_gain_;
   OnSetParametersCallbackHandle::SharedPtr reset_param_handler_;
 
 

--- a/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/aichallenge/workspace/src/aichallenge_submit/simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -187,6 +187,10 @@ rcl_interfaces::msg::SetParametersResult SimplePurePursuit::parameter_callback(c
       external_target_vel_ = parameter.as_double();
       RCLCPP_INFO(SimplePurePursuit::get_logger(), "external_target_vel changed to %f", external_target_vel_);
     } 
+    else if (parameter.get_name() == "steering_tire_angle_gain") {
+      steering_tire_angle_gain_ = parameter.as_double();
+      RCLCPP_INFO(SimplePurePursuit::get_logger(), "steering_tire_angle_gain changed to %f", steering_tire_angle_gain_);
+    } 
   }
   return result;
 }


### PR DESCRIPTION
公式で用意されているsimple_pure_pursuitノード内ではsteering_tire_angle_gain_が起動時パラメタでしか変更できなかったため，rqt_reconfigureで調整できるように変更した．
/control/simple_pure_pursuit_node内のsteering_tire_angle_gainから調整可能です．
![image](https://github.com/user-attachments/assets/def83fc3-d415-4aa4-8166-1050a892d4a8)
